### PR TITLE
Updates from initial review

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/dynamic-text",
-  "version": "1.0.0-pre.7",
+  "version": "1.0.0-pre.8",
   "description": "Dynamic text manager and React component",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/dynamic-text",
-  "version": "1.0.0-pre.8",
+  "version": "1.0.0-pre.10",
   "description": "Dynamic text manager and React component",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/dynamic-text",
-  "version": "1.0.0-pre.13",
+  "version": "1.0.0-pre.15",
   "description": "Dynamic text manager and React component",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/dynamic-text",
-  "version": "1.0.0-pre.10",
+  "version": "1.0.0-pre.13",
   "description": "Dynamic text manager and React component",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -14,9 +14,9 @@ const addDynamicTextStyles = () => {
   element.setAttribute("type", "text/css");
   element.textContent = `
     .readAloudTextEnabled:hover, .readAloudTextSelected {
-      color: black;
-      background-color: #f8ff00;
-      cursor: pointer;
+      color: black !important;
+      background-color: #f8ff00 !important;
+      cursor: pointer !important;
     }
   `;
   document.getElementsByTagName("head")[0].appendChild(element);

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -39,7 +39,7 @@ export const DynamicText: React.FC<Props> = ({ noReadAloud, children, context })
     // this will need to change to an api message
     dynamicText.registerComponent(componentId, (message: DynamicTextMessage) => {
       switch (message.type) {
-        case "enabled":
+        case "readAloudEnabled":
           setEnabled(message.enabled);
           break;
         case "selected":

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -5,6 +5,7 @@ import { DynamicTextInterface, DynamicTextMessage } from "./types";
 
 interface Props {
   noReadAloud?: boolean;
+  inline?: boolean;
   context?: DynamicTextInterface; // allows context to optionally be passed as a prop
 }
 
@@ -23,7 +24,7 @@ const addDynamicTextStyles = () => {
 };
 addDynamicTextStyles();
 
-export const DynamicText: React.FC<Props> = ({ noReadAloud, children, context }) => {
+export const DynamicText: React.FC<Props> = ({ noReadAloud, inline, children, context }) => {
   const dynamicText = context || useDynamicTextContext();
   const readAloud = !noReadAloud;
   const ref = useRef<HTMLDivElement | null>(null);
@@ -53,6 +54,12 @@ export const DynamicText: React.FC<Props> = ({ noReadAloud, children, context })
 
   // select the component when clicked
   const handleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    // ignore clicks on links within dynamic text areas and glossary words
+    const target = e.target as HTMLElement|undefined;
+    if ((target?.tagName === "A") || target?.className.includes("GlossaryWord")) {
+      return;
+    }
+
     // this will need to change to an api message
     dynamicText.selectComponent(id, {
       readAloud,
@@ -64,6 +71,12 @@ export const DynamicText: React.FC<Props> = ({ noReadAloud, children, context })
     readAloud && enabled ? "readAloudTextEnabled" : "",
     readAloud && selected ? "readAloudTextSelected" : ""
   ].join(" ");
+
+  if (inline) {
+    return (
+      <span className={className} onClick={handleClick} ref={ref}>{children}</span>
+    );
+  }
 
   return (
     <div className={className} onClick={handleClick} ref={ref}>{children}</div>

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,3 +15,16 @@ export const useDynamicTextContext = () => {
 
   return currentDynamicTextContext;
 };
+
+// This context is used for containers, like report items, that have dynamic text enabled
+// components that are but run in a host (like the reports) which don't support dynamic text.
+// It provides empty stub functions and it can also be used in tests
+
+export const fakeDynamicTextContext: DynamicTextInterface = {
+  registerComponent: () => undefined,
+  unregisterComponent: () => undefined,
+  selectComponent: () => undefined
+};
+export const FakeDynamicTextContext = createContext<DynamicTextInterface>(fakeDynamicTextContext);
+
+export const useFakeDynamicTextContext = () => useContext(FakeDynamicTextContext);

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,16 +7,11 @@ DynamicTextContext.displayName = "DynamicTextContext";
 export const useDynamicTextContext = () => {
   const currentDynamicTextContext = useContext(DynamicTextContext);
 
-  /*
-
-  remove to see if tests are easier
-
   if (!currentDynamicTextContext) {
     throw new Error(
       "useDynamicTextContext has to be used within <DynamicTextContext.Provider>"
     );
   }
-  */
 
-  return currentDynamicTextContext!;
+  return currentDynamicTextContext;
 };

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -5,7 +5,7 @@ export interface DynamicTextManagerOptions {
 }
 
 const params = new URLSearchParams(window.location.search);
-let rate = parseFloat(params.get("readAloudRate") || "1");
+let rate = parseFloat(params.get("readAloudRate") || "0.7");
 if (isNaN(rate)) {
   rate = 1;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import {getClient, ICustomMessage, sendCustomMessage} from "@concord-consortium/lara-interactive-api";
 
 import { DynamicTextCustomMessageType, DynamicTextInterface, DynamicTextListener, DynamicTextMessage, SelectComponentOptions } from "./types";
@@ -39,14 +38,7 @@ export class DynamicTextProxy implements DynamicTextInterface {
   }
 }
 
-export const useDynamicTextProxy = () => {
-  const [proxy, setProxy] = useState<DynamicTextProxy>();
-
-  useEffect(() => {
-    if (!proxy) {
-      setProxy(new DynamicTextProxy())
-    }
-  }, [proxy]);
-
-  return proxy as DynamicTextProxy;
-}
+// hook to return singleton instance - this needs to exist on initial render
+// so useEffect() can't be used
+const proxy = new DynamicTextProxy();
+export const useDynamicTextProxy = () => proxy;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export type SelectComponentOptions = {
 
 export type DynamicTextMessage =
   { type: "selected", id: string | null } |
-  { type: "enabled", enabled: boolean } |
+  { type: "readAloudEnabled", enabled: boolean } |
   { type: "register", id: string } |
   { type: "unregister", id: string } |
   { type: "select", id: string|null, options?: SelectComponentOptions };


### PR DESCRIPTION
- changed enabled to readAloudEnabled
- changed session storage to store json
- changed proxy context hook to return singleton

other changes (not from review):

- changed to store current utterance which removes the need to track the currently read text separately
- added `!important` to read aloud css to override local css
- set the default read aloud rate to 0.7
- added ignore of clicks on links and glossary words in the component click handler
- added inline render option to allow for multiple choice labels