### PR TITLE
Change required react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/dynamic-text",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Dynamic text manager and React component",
   "main": "index.js",
   "types": "index.d.ts",
@@ -40,8 +40,8 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0",
     "@concord-consortium/lara-interactive-api": ">=1.8.0"
   }
 }


### PR DESCRIPTION
Apparently it works both in AP and QI where react versions are 16 and 17, so we can require just >= 16.